### PR TITLE
ERC2771ForwarderAccount: smart account that acts as ERC-2771 forwarder

### DIFF
--- a/contracts/ERC2771ForwarderAccount.sol
+++ b/contracts/ERC2771ForwarderAccount.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.23;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
+import {SIG_VALIDATION_SUCCESS, SIG_VALIDATION_FAILED} from "@account-abstraction/contracts/core/Helpers.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @title ERC2771ForwarderAccount
+ *
+ * @dev Smart Account that acts as an ERC2771 Trusted Forwarder, forwarding calls to other contract(s) where
+ *      the account is the trusted forwarder, on behalf of the signer of the userOp.
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract ERC2771ForwarderAccount is AccessControl, BaseAccount {
+  bytes32 public constant WITHDRAW_ROLE = keccak256("WITHDRAW_ROLE");
+  bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+  IEntryPoint private immutable _entryPoint;
+  address internal transient _userOpSigner;
+
+  error RequiredEntryPointOrExecutor(address sender);
+  error UserOpSignerNotSet();
+  error CanCallOnlyIfTrustedForwarder(address target);
+  error WrongArrayLength();
+
+  /// @inheritdoc BaseAccount
+  function entryPoint() public view virtual override returns (IEntryPoint) {
+    return _entryPoint;
+  }
+
+  // solhint-disable-next-line no-empty-blocks
+  receive() external payable {}
+
+  modifier resetUserOpSigner() {
+    _;
+    _userOpSigner = address(0);
+  }
+
+  constructor(IEntryPoint anEntryPoint, address admin, address[] memory executors) {
+    _entryPoint = anEntryPoint;
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    for (uint256 i; i < executors.length; i++) {
+      _grantRole(EXECUTOR_ROLE, executors[i]);
+    }
+  }
+
+  // Require the function call went through EntryPoint or authorized executor
+  function _requireFromEntryPointOrExecutor() internal view returns (address sender) {
+    if (msg.sender == address(entryPoint())) {
+      require(_userOpSigner != address(0), UserOpSignerNotSet());
+      return _userOpSigner;
+    }
+    require(hasRole(EXECUTOR_ROLE, msg.sender), RequiredEntryPointOrExecutor(msg.sender));
+    return msg.sender;
+  }
+
+  /**
+   * execute a transaction (called directly from owner, or by entryPoint)
+   * @param dest destination address to call
+   * @param value the value to pass in this call
+   * @param func the calldata to pass in this call
+   */
+  function execute(address dest, uint256 value, bytes calldata func) external resetUserOpSigner {
+    address sender = _requireFromEntryPointOrExecutor();
+    require(_isTrustedByTarget(dest), CanCallOnlyIfTrustedForwarder(dest));
+    Address.functionCallWithValue(dest, abi.encodePacked(func, sender), value);
+  }
+
+  /**
+   * execute a sequence of transactions
+   * @dev to reduce gas consumption for trivial case (no value), use a zero-length array to mean zero value
+   * @param dest an array of destination addresses
+   * @param value an array of values to pass to each call. can be zero-length for no-value calls
+   * @param func an array of calldata to pass to each call
+   */
+  function executeBatch(
+    address[] calldata dest,
+    uint256[] calldata value,
+    bytes[] calldata func
+  ) external resetUserOpSigner {
+    address sender = _requireFromEntryPointOrExecutor();
+    if (dest.length != func.length || (value.length != 0 && value.length != func.length)) revert WrongArrayLength();
+    for (uint256 i = 0; i < dest.length; i++) {
+      require(
+        i == 0 ? _isTrustedByTarget(dest[0]) : (dest[i - 1] == dest[i] || _isTrustedByTarget(dest[i])),
+        CanCallOnlyIfTrustedForwarder(dest[i])
+      );
+      Address.functionCallWithValue(dest[i], abi.encodePacked(func[i], sender), value.length == 0 ? 0 : value[i]);
+    }
+  }
+
+  /// implement template method of BaseAccount
+  function _validateSignature(
+    PackedUserOperation calldata userOp,
+    bytes32 userOpHash
+  ) internal virtual override returns (uint256 validationData) {
+    bytes32 hash = MessageHashUtils.toEthSignedMessageHash(userOpHash);
+    address recovered = ECDSA.recover(hash, userOp.signature);
+    if (!hasRole(EXECUTOR_ROLE, recovered)) return SIG_VALIDATION_FAILED;
+    // Store the _userOpSigner so it can be used as _msgSender by execute and executeBatch
+    _userOpSigner = recovered;
+    return SIG_VALIDATION_SUCCESS;
+  }
+
+  /**
+   * @dev Returns whether the target trusts this forwarder.
+   *
+   * This function performs a static call to the target contract calling the
+   * {ERC2771Context-isTrustedForwarder} function.
+   *
+   * Copied from ERC2771Forwarder.sol (OZ-contracts)
+   */
+  function _isTrustedByTarget(address target) private view returns (bool) {
+    bytes memory encodedParams = abi.encodeCall(ERC2771Context.isTrustedForwarder, (address(this)));
+
+    bool success;
+    uint256 returnSize;
+    uint256 returnValue;
+    // solhint-disable-next-line no-inline-assembly
+    assembly ("memory-safe") {
+      // Perform the staticcall and save the result in the scratch space.
+      // | Location  | Content  | Content (Hex)                                                      |
+      // |-----------|----------|--------------------------------------------------------------------|
+      // |           |          |                                                           result ↓ |
+      // | 0x00:0x1F | selector | 0x0000000000000000000000000000000000000000000000000000000000000001 |
+      success := staticcall(gas(), target, add(encodedParams, 0x20), mload(encodedParams), 0, 0x20)
+      returnSize := returndatasize()
+      returnValue := mload(0)
+    }
+
+    return success && returnSize >= 0x20 && returnValue > 0;
+  }
+
+  /**
+   * check current account deposit in the entryPoint
+   */
+  function getDeposit() public view returns (uint256) {
+    return entryPoint().balanceOf(address(this));
+  }
+
+  /**
+   * deposit more funds for this account in the entryPoint
+   */
+  function addDeposit() public payable {
+    entryPoint().depositTo{value: msg.value}(address(this));
+  }
+
+  /**
+   * withdraw value from the account's deposit
+   * @param withdrawAddress target to send to
+   * @param amount to withdraw
+   */
+  function withdrawDepositTo(address payable withdrawAddress, uint256 amount) public onlyRole(WITHDRAW_ROLE) {
+    entryPoint().withdrawTo(withdrawAddress, amount);
+  }
+}

--- a/contracts/mock/ERC20With2771.sol
+++ b/contracts/mock/ERC20With2771.sol
@@ -1,0 +1,40 @@
+//SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+
+contract ERC20With2771 is ERC20, ERC2771Context {
+  uint8 internal immutable _decimals;
+
+  constructor(
+    string memory name_,
+    string memory symbol_,
+    uint256 initialSupply,
+    uint8 decimals_,
+    address trustedForwarder
+  ) ERC20(name_, symbol_) ERC2771Context(trustedForwarder) {
+    _decimals = decimals_;
+    _mint(msg.sender, initialSupply);
+  }
+
+  function decimals() public view virtual override returns (uint8) {
+    return _decimals;
+  }
+
+  /// @inheritdoc ERC2771Context
+  function _contextSuffixLength() internal view override(Context, ERC2771Context) returns (uint256) {
+    return ERC2771Context._contextSuffixLength();
+  }
+
+  /// @inheritdoc ERC2771Context
+  function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
+    return ERC2771Context._msgSender();
+  }
+
+  /// @inheritdoc ERC2771Context
+  function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
+    return ERC2771Context._msgData();
+  }
+}

--- a/test/test-access-control-account.js
+++ b/test/test-access-control-account.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 const { _W, getRole, amountFunction, getAddress } = require("@ensuro/utils/js/utils");
-const { setupChain, initForkCurrency } = require("@ensuro/utils/js/test-utils");
+const { setupChain, initForkCurrency, initCurrency } = require("@ensuro/utils/js/test-utils");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
@@ -16,268 +16,326 @@ const ADDRESSES = {
   ENTRYPOINT: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
 };
 
-async function setUp() {
-  const [, exec1, exec2, anon, withdraw, admin] = await ethers.getSigners();
+const variants = [
+  {
+    name: "AccessControlAccount",
+    fixture: async () => {
+      await setupChain(null);
+      const [, exec1, exec2, anon, withdraw, admin] = await ethers.getSigners();
 
-  const usdc = await initForkCurrency(ADDRESSES.USDC, ADDRESSES.USDCWhale, [exec1, exec2], [_A(100), _A(100)]);
-  const ep = await ethers.getContractAt("IEntryPoint", ADDRESSES.ENTRYPOINT);
-  const AccessControlAccount = await ethers.getContractFactory("AccessControlAccount");
-  const acAcc = await AccessControlAccount.deploy(ep, admin, [exec1, exec2]);
-  const roles = {
-    admin: getRole("DEFAULT_ADMIN_ROLE"),
-    exec: getRole("EXECUTOR_ROLE"),
-    withdraw: getRole("WITHDRAW_ROLE"),
-  };
+      const usdc = await initForkCurrency(ADDRESSES.USDC, ADDRESSES.USDCWhale, [exec1, exec2], [_A(100), _A(100)]);
+      const ep = await ethers.getContractAt("IEntryPoint", ADDRESSES.ENTRYPOINT);
+      const AccessControlAccount = await ethers.getContractFactory("AccessControlAccount");
+      const acAcc = await AccessControlAccount.deploy(ep, admin, [exec1, exec2]);
+      const roles = {
+        admin: getRole("DEFAULT_ADMIN_ROLE"),
+        exec: getRole("EXECUTOR_ROLE"),
+        withdraw: getRole("WITHDRAW_ROLE"),
+      };
 
-  return {
-    ep,
-    AccessControlAccount,
-    acAcc,
-    exec1,
-    exec2,
-    anon,
-    withdraw,
-    admin,
-    roles,
-    usdc,
-  };
-}
+      return {
+        ep,
+        AccessControlAccount,
+        acAcc,
+        exec1,
+        exec2,
+        anon,
+        withdraw,
+        admin,
+        roles,
+        usdc,
+      };
+    },
+  },
+  {
+    name: "ERC2771ForwarderAccount",
+    fixture: async () => {
+      await setupChain(null);
+      const [, exec1, exec2, anon, withdraw, admin] = await ethers.getSigners();
 
-describe("AccessControlAccount contract tests", function () {
-  before(async () => {
-    await setupChain(null);
-  });
+      const ep = await ethers.getContractAt("IEntryPoint", ADDRESSES.ENTRYPOINT);
+      const ERC2771ForwarderAccount = await ethers.getContractFactory("ERC2771ForwarderAccount");
+      const acAcc = await ERC2771ForwarderAccount.deploy(ep, admin, [exec1, exec2]);
+      const usdc = await initCurrency(
+        { decimals: 6, initial_supply: _A(10000), extraArgs: [acAcc], contractClass: "ERC20With2771" },
+        [exec1, exec2],
+        [_A(100), _A(100)]
+      );
+      const roles = {
+        admin: getRole("DEFAULT_ADMIN_ROLE"),
+        exec: getRole("EXECUTOR_ROLE"),
+        withdraw: getRole("WITHDRAW_ROLE"),
+      };
 
-  it("Constructs with the right permissions and EP", async () => {
-    const { acAcc, anon, exec1, exec2, admin, roles } = await helpers.loadFixture(setUp);
-    expect(await acAcc.hasRole(roles.admin, admin)).to.equal(true);
-    expect(await acAcc.hasRole(roles.admin, anon)).to.equal(false);
-    expect(await acAcc.hasRole(roles.exec, exec1)).to.equal(true);
-    expect(await acAcc.hasRole(roles.exec, exec2)).to.equal(true);
-    expect(await acAcc.hasRole(roles.exec, anon)).to.equal(false);
-    expect(await acAcc.entryPoint()).to.equal(ADDRESSES.ENTRYPOINT);
-  });
+      return {
+        ep,
+        ERC2771ForwarderAccount,
+        acAcc,
+        exec1,
+        exec2,
+        anon,
+        withdraw,
+        admin,
+        roles,
+        usdc,
+      };
+    },
+  },
+];
 
-  it("Can receive eth, deposits and only WITHDRAW_ROLE can withdraw", async () => {
-    const { acAcc, anon, withdraw, admin, roles, ep } = await helpers.loadFixture(setUp);
-    expect(await hre.ethers.provider.getBalance(acAcc)).to.equal(0);
-    await expect(() => withdraw.sendTransaction({ to: acAcc, value: _W(1) })).to.changeEtherBalance(acAcc, _W(1));
-    expect(await hre.ethers.provider.getBalance(acAcc)).to.equal(_W(1));
+variants.forEach((variant) => {
+  describe(`${variant.name} contract tests`, function () {
+    it("Constructs with the right permissions and EP", async () => {
+      const { acAcc, anon, exec1, exec2, admin, roles } = await helpers.loadFixture(variant.fixture);
+      expect(await acAcc.hasRole(roles.admin, admin)).to.equal(true);
+      expect(await acAcc.hasRole(roles.admin, anon)).to.equal(false);
+      expect(await acAcc.hasRole(roles.exec, exec1)).to.equal(true);
+      expect(await acAcc.hasRole(roles.exec, exec2)).to.equal(true);
+      expect(await acAcc.hasRole(roles.exec, anon)).to.equal(false);
+      expect(await acAcc.entryPoint()).to.equal(ADDRESSES.ENTRYPOINT);
+    });
 
-    await expect(() => acAcc.addDeposit({ value: _W(2) })).to.changeEtherBalance(ep, _W(2));
-    expect(await ep.balanceOf(acAcc)).to.equal(_W(2));
+    it("Can receive eth, deposits and only WITHDRAW_ROLE can withdraw", async () => {
+      const { acAcc, anon, withdraw, admin, roles, ep } = await helpers.loadFixture(variant.fixture);
+      expect(await hre.ethers.provider.getBalance(acAcc)).to.equal(0);
+      await expect(() => withdraw.sendTransaction({ to: acAcc, value: _W(1) })).to.changeEtherBalance(acAcc, _W(1));
+      expect(await hre.ethers.provider.getBalance(acAcc)).to.equal(_W(1));
 
-    await expect(acAcc.connect(withdraw).withdrawDepositTo(anon, _W(1)))
-      .to.be.revertedWithCustomError(acAcc, "AccessControlUnauthorizedAccount")
-      .withArgs(withdraw, roles.withdraw);
+      await expect(() => acAcc.addDeposit({ value: _W(2) })).to.changeEtherBalance(ep, _W(2));
+      expect(await ep.balanceOf(acAcc)).to.equal(_W(2));
 
-    await expect(acAcc.connect(anon).grantRole(roles.withdraw, withdraw))
-      .to.be.revertedWithCustomError(acAcc, "AccessControlUnauthorizedAccount")
-      .withArgs(anon, roles.admin);
+      await expect(acAcc.connect(withdraw).withdrawDepositTo(anon, _W(1)))
+        .to.be.revertedWithCustomError(acAcc, "AccessControlUnauthorizedAccount")
+        .withArgs(withdraw, roles.withdraw);
 
-    await expect(acAcc.connect(admin).grantRole(roles.withdraw, withdraw)).not.to.be.reverted;
+      await expect(acAcc.connect(anon).grantRole(roles.withdraw, withdraw))
+        .to.be.revertedWithCustomError(acAcc, "AccessControlUnauthorizedAccount")
+        .withArgs(anon, roles.admin);
 
-    await expect(() => acAcc.connect(withdraw).withdrawDepositTo(anon, _W("0.5"))).to.changeEtherBalance(
-      anon,
-      _W("0.5")
-    );
-    expect(await ep.balanceOf(acAcc)).to.equal(_W("1.5"));
-    expect(await acAcc.getDeposit()).to.equal(_W("1.5"));
-  });
+      await expect(acAcc.connect(admin).grantRole(roles.withdraw, withdraw)).not.to.be.reverted;
 
-  it("Can execute when called directly", async () => {
-    const { acAcc, anon, exec1, usdc } = await helpers.loadFixture(setUp);
-    const approveExec1 = usdc.interface.encodeFunctionData("approve", [getAddress(exec1), MaxUint256]);
-    await expect(acAcc.connect(anon).execute(usdc, 0, approveExec1))
-      .to.be.revertedWithCustomError(acAcc, "RequiredEntryPointOrExecutor")
-      .withArgs(anon);
-    expect(await usdc.allowance(acAcc, exec1)).to.equal(0);
-    await expect(acAcc.connect(exec1).execute(usdc, 0, approveExec1)).not.to.be.reverted;
-    expect(await usdc.allowance(acAcc, exec1)).to.equal(MaxUint256);
-  });
+      await expect(() => acAcc.connect(withdraw).withdrawDepositTo(anon, _W("0.5"))).to.changeEtherBalance(
+        anon,
+        _W("0.5")
+      );
+      expect(await ep.balanceOf(acAcc)).to.equal(_W("1.5"));
+      expect(await acAcc.getDeposit()).to.equal(_W("1.5"));
+    });
 
-  it("Can execute when called through entryPoint", async () => {
-    const { acAcc, anon, exec1, usdc, ep } = await helpers.loadFixture(setUp);
-    const approveExec1 = usdc.interface.encodeFunctionData("approve", [getAddress(exec1), MaxUint256]);
-    const executeCall = acAcc.interface.encodeFunctionData("execute", [getAddress(usdc), 0, approveExec1]);
+    it("Can execute when called directly", async () => {
+      const { acAcc, anon, exec1, exec2, usdc } = await helpers.loadFixture(variant.fixture);
+      const approveExec1 = usdc.interface.encodeFunctionData("approve", [getAddress(exec1), MaxUint256]);
+      await expect(acAcc.connect(anon).execute(usdc, 0, approveExec1))
+        .to.be.revertedWithCustomError(acAcc, "RequiredEntryPointOrExecutor")
+        .withArgs(anon);
+      // The msgSender that interacts with the ERC20 contract changes from one variant to the other
+      const msgSender = variant.name === "AccessControlAccount" ? acAcc : exec2;
+      expect(await usdc.allowance(msgSender, exec1)).to.equal(0);
+      await expect(acAcc.connect(exec2).execute(usdc, 0, approveExec1)).not.to.be.reverted;
+      expect(await usdc.allowance(msgSender, exec1)).to.equal(MaxUint256);
+    });
 
-    await expect(() => acAcc.addDeposit({ value: _W(9) })).to.changeEtherBalance(ep, _W(9));
-    expect(await ep.balanceOf(acAcc)).to.equal(_W(9));
+    it("Can execute when called through entryPoint", async () => {
+      const { acAcc, anon, exec1, exec2, usdc, ep } = await helpers.loadFixture(variant.fixture);
+      const approveExec1 = usdc.interface.encodeFunctionData("approve", [getAddress(exec1), MaxUint256]);
+      const executeCall = acAcc.interface.encodeFunctionData("execute", [getAddress(usdc), 0, approveExec1]);
 
-    // Construct the userOp manually
-    const nonce = await acAcc.getNonce();
-    const userOp = [
-      getAddress(acAcc),
-      nonce,
-      ethers.toUtf8Bytes(""),
-      executeCall,
-      packAccountGasLimits(999999, 999999),
-      999999,
-      packAccountGasLimits(1e9, 1e9),
-      ethers.toUtf8Bytes(""),
-    ];
-    const userOpHash = await ep.getUserOpHash([...userOp, ethers.toUtf8Bytes("")]);
+      await expect(() => acAcc.addDeposit({ value: _W(9) })).to.changeEtherBalance(ep, _W(9));
+      expect(await ep.balanceOf(acAcc)).to.equal(_W(9));
 
-    // Same but using UserOp object and compare userOpHash
-    const userOpObj = {
-      sender: getAddress(acAcc),
-      nonce: nonce,
-      initCode: "0x",
-      callData: executeCall,
-      callGasLimit: 999999,
-      verificationGasLimit: 999999,
-      preVerificationGas: 999999,
-      maxFeePerGas: 1e9,
-      maxPriorityFeePerGas: 1e9,
-      paymaster: ZeroAddress,
-      paymasterData: "0x",
-      paymasterVerificationGasLimit: 0,
-      paymasterPostOpGasLimit: 0,
-      signature: "0x",
-    };
-    const { chainId } = await hre.ethers.provider.getNetwork();
-    expect(getUserOpHash(userOpObj, ADDRESSES.ENTRYPOINT, chainId)).to.equal(userOpHash);
+      // Construct the userOp manually
+      const nonce = await acAcc.getNonce();
+      const userOp = [
+        getAddress(acAcc),
+        nonce,
+        ethers.toUtf8Bytes(""),
+        executeCall,
+        packAccountGasLimits(999999, 999999),
+        999999,
+        packAccountGasLimits(1e9, 1e9),
+        ethers.toUtf8Bytes(""),
+      ];
+      const userOpHash = await ep.getUserOpHash([...userOp, ethers.toUtf8Bytes("")]);
 
-    // Sign the hash
-    const message = userOpHash;
-    const anonSignature = await anon.signMessage(ethers.getBytes(message));
-    const signature = await exec1.signMessage(ethers.getBytes(message));
-    await expect(ep.handleOps([[...userOp, anonSignature]], anon))
-      .to.be.revertedWithCustomError(ep, "FailedOp")
-      .withArgs(0, "AA24 signature error");
+      // Same but using UserOp object and compare userOpHash
+      const userOpObj = {
+        sender: getAddress(acAcc),
+        nonce: nonce,
+        initCode: "0x",
+        callData: executeCall,
+        callGasLimit: 999999,
+        verificationGasLimit: 999999,
+        preVerificationGas: 999999,
+        maxFeePerGas: 1e9,
+        maxPriorityFeePerGas: 1e9,
+        paymaster: ZeroAddress,
+        paymasterData: "0x",
+        paymasterVerificationGasLimit: 0,
+        paymasterPostOpGasLimit: 0,
+        signature: "0x",
+      };
+      const { chainId } = await hre.ethers.provider.getNetwork();
+      expect(getUserOpHash(userOpObj, ADDRESSES.ENTRYPOINT, chainId)).to.equal(userOpHash);
 
-    // Call the validateUserOp function on the wallet contract
-    await helpers.impersonateAccount(ep.target);
-    const epSigner = await hre.ethers.getSigner(ep.target);
-    const validateTx = await acAcc.connect(epSigner).validateUserOp(
-      [...userOp, signature],
-      userOpHash,
-      0 // missingAccountFunds
-    );
-    await validateTx.wait();
+      // Sign the hash
+      const message = userOpHash;
+      const anonSignature = await anon.signMessage(ethers.getBytes(message));
+      const signature = await exec2.signMessage(ethers.getBytes(message));
+      await expect(ep.handleOps([[...userOp, anonSignature]], anon))
+        .to.be.revertedWithCustomError(ep, "FailedOp")
+        .withArgs(0, "AA24 signature error");
 
-    // Use debug_traceTransaction to get the execution trace of the validation call
-    const trace = await hre.network.provider.send("debug_traceTransaction", [
-      validateTx.hash,
-      { disableStorage: true, disableMemory: true, disableStack: true },
-    ]);
+      // Call the validateUserOp function on the wallet contract
+      await helpers.impersonateAccount(ep.target);
+      const epSigner = await hre.ethers.getSigner(ep.target);
+      const validateTx = await acAcc.connect(epSigner).validateUserOp(
+        [...userOp, signature],
+        userOpHash,
+        0 // missingAccountFunds
+      );
+      await validateTx.wait();
 
-    const executedOpcodes = trace.structLogs.map((log) => log.op);
-    await expect(executedOpcodes).to.not.contain("TIMESTAMP");
+      // Use debug_traceTransaction to get the execution trace of the validation call
+      const trace = await hre.network.provider.send("debug_traceTransaction", [
+        validateTx.hash,
+        { disableStorage: true, disableMemory: true, disableStack: true },
+      ]);
 
-    expect(await usdc.allowance(acAcc, exec1)).to.equal(0);
-    await expect(ep.handleOps([[...userOp, signature]], anon)).not.to.be.reverted;
-    expect(await usdc.allowance(acAcc, exec1)).to.equal(MaxUint256);
-  });
+      const executedOpcodes = trace.structLogs.map((log) => log.op);
+      await expect(executedOpcodes).to.not.contain("TIMESTAMP");
 
-  it("Can executeBatch when called directly", async () => {
-    const { acAcc, anon, exec1, exec2, usdc } = await helpers.loadFixture(setUp);
+      const msgSender = variant.name === "AccessControlAccount" ? acAcc : exec2;
+      expect(await usdc.allowance(msgSender, exec1)).to.equal(0);
+      await expect(ep.handleOps([[...userOp, signature]], anon)).not.to.be.reverted;
+      expect(await usdc.allowance(msgSender, exec1)).to.equal(MaxUint256);
+    });
 
-    // Setup - send some initial money
-    await usdc.connect(exec1).transfer(acAcc, _A(10));
-    await usdc.connect(exec2).transfer(acAcc, _A(20));
-    expect(await usdc.balanceOf(acAcc)).to.equal(_A(30));
+    it("Can executeBatch when called directly", async () => {
+      const { acAcc, anon, exec1, exec2, usdc } = await helpers.loadFixture(variant.fixture);
 
-    const calls = [
-      usdc.interface.encodeFunctionData("transfer", [getAddress(exec1), _A(5)]),
-      usdc.interface.encodeFunctionData("transfer", [getAddress(exec2), _A(10)]),
-    ];
-    await expect(acAcc.connect(anon).executeBatch([usdc, usdc], [], calls))
-      .to.be.revertedWithCustomError(acAcc, "RequiredEntryPointOrExecutor")
-      .withArgs(anon);
-    await expect(() => acAcc.connect(exec2).executeBatch([usdc, usdc], [], calls)).to.changeTokenBalances(
-      usdc,
-      [exec1, exec2],
-      [_A(5), _A(10)]
-    );
-    expect(await usdc.balanceOf(acAcc)).to.equal(_A(15));
-  });
+      if (variant.name === "AccessControlAccount") {
+        // Setup - send some initial money
+        await usdc.connect(exec1).transfer(acAcc, _A(10));
+        await usdc.connect(exec2).transfer(acAcc, _A(20));
+        expect(await usdc.balanceOf(acAcc)).to.equal(_A(30));
+      }
 
-  it("Can executeBatch when called directly (with value)", async () => {
-    const { acAcc, exec1, exec2, ep } = await helpers.loadFixture(setUp);
+      const calls = [
+        usdc.interface.encodeFunctionData("transfer", [getAddress(exec1), _A(5)]),
+        usdc.interface.encodeFunctionData("transfer", [getAddress(anon), _A(10)]),
+      ];
+      await expect(acAcc.connect(anon).executeBatch([usdc, usdc], [], calls))
+        .to.be.revertedWithCustomError(acAcc, "RequiredEntryPointOrExecutor")
+        .withArgs(anon);
+      const msgSender = variant.name === "AccessControlAccount" ? acAcc : exec2;
+      await expect(() => acAcc.connect(exec2).executeBatch([usdc, usdc], [], calls)).to.changeTokenBalances(
+        usdc,
+        [exec1, anon, msgSender],
+        [_A(5), _A(10), _A(-15)]
+      );
+    });
 
-    // Setup - send some eth to acAcc and deposit
-    await expect(() => acAcc.addDeposit({ value: _W(5) })).to.changeEtherBalance(ep, _W(5));
-    expect(await ep.balanceOf(acAcc)).to.equal(_W(5));
-    await expect(() => exec1.sendTransaction({ to: acAcc, value: _W(3) })).to.changeEtherBalance(acAcc, _W(3));
+    it("Can executeBatch when called directly (with value)", async () => {
+      const { acAcc, exec1, exec2, ep } = await helpers.loadFixture(variant.fixture);
 
-    const calls = [
-      ep.interface.encodeFunctionData("depositTo", [getAddress(exec2)]),
-      ep.interface.encodeFunctionData("addStake", [3600]),
-    ];
-    await expect(acAcc.connect(exec1).executeBatch([ep, ep], [], calls)).to.be.revertedWith("no stake specified");
-    await expect(acAcc.connect(exec1).executeBatch([ep, ep], [_W(1)], calls)).to.be.revertedWithCustomError(
-      acAcc,
-      "WrongArrayLength"
-    );
-    await expect(acAcc.connect(exec1).executeBatch([ep], [], calls)).to.be.revertedWithCustomError(
-      acAcc,
-      "WrongArrayLength"
-    );
-    await expect(() => acAcc.connect(exec1).executeBatch([ep, ep], [_W(1), _W(2)], calls)).to.changeEtherBalance(
-      ep,
-      _W(3)
-    );
-    expect(await ep.balanceOf(acAcc)).to.equal(_W(5));
-    expect(await ep.balanceOf(exec2)).to.equal(_W(1)); // The deposit was made on behalft of exec2
-    expect((await ep.getDepositInfo(acAcc)).stake).to.equal(_W(2));
-  });
+      // Setup - send some eth to acAcc and deposit
+      await expect(() => acAcc.addDeposit({ value: _W(5) })).to.changeEtherBalance(ep, _W(5));
+      expect(await ep.balanceOf(acAcc)).to.equal(_W(5));
+      await expect(() => exec1.sendTransaction({ to: acAcc, value: _W(3) })).to.changeEtherBalance(acAcc, _W(3));
 
-  it("Can executeBatch when called through entryPoint", async () => {
-    const { acAcc, anon, exec1, exec2, usdc, ep } = await helpers.loadFixture(setUp);
-    // Setup - send some initial money
-    await usdc.connect(exec1).transfer(acAcc, _A(10));
-    await usdc.connect(exec2).transfer(acAcc, _A(20));
-    expect(await usdc.balanceOf(acAcc)).to.equal(_A(30));
+      const calls = [
+        ep.interface.encodeFunctionData("depositTo", [getAddress(exec2)]),
+        ep.interface.encodeFunctionData("addStake", [3600]),
+      ];
+      if (variant.name == "AccessControlAccount") {
+        await expect(acAcc.connect(exec1).executeBatch([ep, ep], [], calls)).to.be.revertedWith("no stake specified");
+      } else {
+        await expect(acAcc.connect(exec1).executeBatch([ep, ep], [], calls))
+          .to.be.revertedWithCustomError(acAcc, "CanCallOnlyIfTrustedForwarder")
+          .withArgs(ep);
+      }
+      await expect(acAcc.connect(exec1).executeBatch([ep, ep], [_W(1)], calls)).to.be.revertedWithCustomError(
+        acAcc,
+        "WrongArrayLength"
+      );
+      await expect(acAcc.connect(exec1).executeBatch([ep], [], calls)).to.be.revertedWithCustomError(
+        acAcc,
+        "WrongArrayLength"
+      );
+      if (variant.name == "AccessControlAccount") {
+        await expect(() => acAcc.connect(exec1).executeBatch([ep, ep], [_W(1), _W(2)], calls)).to.changeEtherBalance(
+          ep,
+          _W(3)
+        );
+        expect(await ep.balanceOf(acAcc)).to.equal(_W(5));
+        expect(await ep.balanceOf(exec2)).to.equal(_W(1)); // The deposit was made on behalft of exec2
+        expect((await ep.getDepositInfo(acAcc)).stake).to.equal(_W(2));
+      } else {
+        // Keeps failing because it can't call the EP
+        await expect(acAcc.connect(exec1).executeBatch([ep, ep], [_W(1), _W(2)], calls))
+          .to.be.revertedWithCustomError(acAcc, "CanCallOnlyIfTrustedForwarder")
+          .withArgs(ep);
+      }
+    });
 
-    const calls = [
-      usdc.interface.encodeFunctionData("transfer", [getAddress(exec1), _A(5)]),
-      usdc.interface.encodeFunctionData("transfer", [getAddress(exec2), _A(10)]),
-    ];
-    const executeBatchCall = acAcc.interface.encodeFunctionData("executeBatch", [
-      [getAddress(usdc), getAddress(usdc)],
-      [],
-      calls,
-    ]);
+    it("Can executeBatch when called through entryPoint", async () => {
+      const { acAcc, anon, exec1, exec2, usdc, ep } = await helpers.loadFixture(variant.fixture);
 
-    await expect(() => acAcc.addDeposit({ value: _W(9) })).to.changeEtherBalance(ep, _W(9));
-    expect(await ep.balanceOf(acAcc)).to.equal(_W(9));
+      if (variant.name === "AccessControlAccount") {
+        // Setup - send some initial money
+        await usdc.connect(exec1).transfer(acAcc, _A(10));
+        await usdc.connect(exec2).transfer(acAcc, _A(20));
+        expect(await usdc.balanceOf(acAcc)).to.equal(_A(30));
+      }
 
-    const nonce = await acAcc.getNonce();
-    const userOpObj = {
-      sender: getAddress(acAcc),
-      nonce: nonce,
-      initCode: "0x",
-      callData: executeBatchCall,
-      callGasLimit: 999999,
-      verificationGasLimit: 999999,
-      preVerificationGas: 999999,
-      maxFeePerGas: 1e9,
-      maxPriorityFeePerGas: 1e9,
-      paymaster: ZeroAddress,
-      paymasterData: "0x",
-      paymasterVerificationGasLimit: 0,
-      paymasterPostOpGasLimit: 0,
-      signature: "0x",
-    };
-    const { chainId } = await hre.ethers.provider.getNetwork();
-    const userOpHash = getUserOpHash(userOpObj, ADDRESSES.ENTRYPOINT, chainId);
+      const calls = [
+        usdc.interface.encodeFunctionData("transfer", [getAddress(exec1), _A(5)]),
+        usdc.interface.encodeFunctionData("transfer", [getAddress(anon), _A(10)]),
+      ];
+      const executeBatchCall = acAcc.interface.encodeFunctionData("executeBatch", [
+        [getAddress(usdc), getAddress(usdc)],
+        [],
+        calls,
+      ]);
 
-    const userOp = packedUserOpAsArray(packUserOp(userOpObj), false);
-    // Sign the hash
-    const message = userOpHash;
-    const anonSignature = await anon.signMessage(ethers.getBytes(message));
-    const signature = await exec1.signMessage(ethers.getBytes(message));
-    await expect(ep.handleOps([[...userOp, anonSignature]], anon))
-      .to.be.revertedWithCustomError(ep, "FailedOp")
-      .withArgs(0, "AA24 signature error");
+      await expect(() => acAcc.addDeposit({ value: _W(9) })).to.changeEtherBalance(ep, _W(9));
+      expect(await ep.balanceOf(acAcc)).to.equal(_W(9));
 
-    expect(await usdc.balanceOf(acAcc)).to.equal(_A(30));
-    await expect(() => ep.handleOps([[...userOp, signature]], anon)).to.changeTokenBalances(
-      usdc,
-      [exec1, exec2],
-      [_A(5), _A(10)]
-    );
-    expect(await usdc.balanceOf(acAcc)).to.equal(_A(15));
+      const nonce = await acAcc.getNonce();
+      const userOpObj = {
+        sender: getAddress(acAcc),
+        nonce: nonce,
+        initCode: "0x",
+        callData: executeBatchCall,
+        callGasLimit: 999999,
+        verificationGasLimit: 999999,
+        preVerificationGas: 999999,
+        maxFeePerGas: 1e9,
+        maxPriorityFeePerGas: 1e9,
+        paymaster: ZeroAddress,
+        paymasterData: "0x",
+        paymasterVerificationGasLimit: 0,
+        paymasterPostOpGasLimit: 0,
+        signature: "0x",
+      };
+      const { chainId } = await hre.ethers.provider.getNetwork();
+      const userOpHash = getUserOpHash(userOpObj, ADDRESSES.ENTRYPOINT, chainId);
+
+      const userOp = packedUserOpAsArray(packUserOp(userOpObj), false);
+      // Sign the hash
+      const message = userOpHash;
+      const anonSignature = await anon.signMessage(ethers.getBytes(message));
+      const signature = await exec2.signMessage(ethers.getBytes(message));
+      await expect(ep.handleOps([[...userOp, anonSignature]], anon))
+        .to.be.revertedWithCustomError(ep, "FailedOp")
+        .withArgs(0, "AA24 signature error");
+
+      const msgSender = variant.name === "AccessControlAccount" ? acAcc : exec2;
+      await expect(() => ep.handleOps([[...userOp, signature]], anon)).to.changeTokenBalances(
+        usdc,
+        [exec1, anon, msgSender],
+        [_A(5), _A(10), _A(-15)]
+      );
+    });
   });
 });


### PR DESCRIPTION
Uses the signer of the userOp as the _msgSender that is added to the call, following the ERC-2771 standard.