### PR TITLE
ERC2771ForwarderAccount: fix simulation issue by adding sender context to executeUserOp calldata

### DIFF
--- a/contracts/ERC2771ForwarderAccount.sol
+++ b/contracts/ERC2771ForwarderAccount.sol
@@ -77,6 +77,9 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
     revert OnlyExecuteUserOpAllowed();
   }
 
+  /**
+   * @dev extracts the signer from the userop call data
+   */
   function _getSigner(PackedUserOperation calldata userop, bytes32 userOpHash) internal pure returns (address) {
     bytes32 hash = MessageHashUtils.toEthSignedMessageHash(userOpHash);
     return ECDSA.recover(hash, userop.signature);
@@ -84,23 +87,27 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
 
   /**
    * @dev Validates that the user operation is well formed and that the destination is correct. Does not validate signature.
+   * @return expectedSigner The address included in the call data, expected to be the signer of the userOp
    * @return call A Call struct containing the call to be made
    */
   function _validateAndDecodeCall(
     PackedUserOperation calldata userOp,
     bytes32 userOpHash
-  ) internal pure returns (Call memory call) {
-    require(userOp.callData.length >= 56 && bytes4(userOp.callData[0:4]) == this.executeUserOp.selector, InvalidCall());
-    (call.target, call.value, call.data) = abi.decode(userOp.callData[4:], (address, uint256, bytes));
+  ) internal pure returns (address expectedSigner, Call memory call) {
+    require(userOp.callData.length >= 80 && bytes4(userOp.callData[0:4]) == this.executeUserOp.selector, InvalidCall());
+    (expectedSigner, call.target, call.value, call.data) = abi.decode(
+      userOp.callData[4:],
+      (address, address, uint256, bytes)
+    );
     if (call.target == address(0)) {
       // This is an if and not a require to avoid evaluating the _getSigner call in the happy path
       revert InvalidTarget(ERC2771Context(call.target), _getSigner(userOp, userOpHash));
     }
   }
 
-  function _isAuthorized(address signer, address target) internal view returns (bool) {
+  function _isAuthorized(address signer, address expectedSigner, address target) internal view returns (bool) {
     ERC2771ForwarderAccountStorage storage $ = _getAccountStorage();
-    return $.targets[signer] == ERC2771Context(target);
+    return signer == expectedSigner && $.targets[signer] == ERC2771Context(target);
   }
 
   /**
@@ -129,9 +136,9 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
     PackedUserOperation calldata userOp,
     bytes32 userOpHash
   ) internal virtual override returns (uint256 validationData) {
-    Call memory call = _validateAndDecodeCall(userOp, userOpHash);
+    (address expectedSigner, Call memory call) = _validateAndDecodeCall(userOp, userOpHash);
     address signer = _getSigner(userOp, userOpHash);
-    if (!_isAuthorized(signer, call.target)) {
+    if (!_isAuthorized(signer, expectedSigner, call.target)) {
       return SIG_VALIDATION_FAILED;
     }
     return SIG_VALIDATION_SUCCESS;
@@ -139,8 +146,8 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
 
   /**
    * @dev Executes a user operation by forwarding the call to the target contract with the signer as the msgSender.
-   *      It re-validates the signature and checks that the signer is authorized. Reverts with InvalidTarget if it isn't.
-   *      The calldata is expected to contain this function's selector followed by an ABI-encoded Call:
+   *      The calldata is expected to contain this function's selector followed the signer and the ABI-encoded call:
+   *         - signer (address): the signer of the userop, must match the signature
    *         - dest (address): the target contract address (must be the same as _target)
    *         - value (uint256): the amount of ETH to send with the call
    *         - func (bytes): the calldata for the target function
@@ -149,12 +156,12 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
    * @param userOpHash The hash of the user operation, used for signature verification.
    */
   function executeUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash) external override {
-    Call memory call = _validateAndDecodeCall(userOp, userOpHash);
-    address signer = _getSigner(userOp, userOpHash);
+    _requireFromEntryPoint();
 
-    require(_isAuthorized(signer, call.target), InvalidTarget(ERC2771Context(call.target), signer));
+    // We can trust that expectedSigner is the userop signer because it was checked in validateSignature
+    (address expectedSigner, Call memory call) = _validateAndDecodeCall(userOp, userOpHash);
 
-    Address.functionCallWithValue(call.target, abi.encodePacked(call.data, signer), call.value);
+    Address.functionCallWithValue(call.target, abi.encodePacked(call.data, expectedSigner), call.value);
   }
 
   /**

--- a/contracts/ERC2771ForwarderAccount.sol
+++ b/contracts/ERC2771ForwarderAccount.sol
@@ -77,9 +77,6 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
     revert OnlyExecuteUserOpAllowed();
   }
 
-  /**
-   * @dev extracts the signer from the userop call data
-   */
   function _getSigner(PackedUserOperation calldata userop, bytes32 userOpHash) internal pure returns (address) {
     bytes32 hash = MessageHashUtils.toEthSignedMessageHash(userOpHash);
     return ECDSA.recover(hash, userop.signature);

--- a/contracts/ERC2771ForwarderAccount.sol
+++ b/contracts/ERC2771ForwarderAccount.sol
@@ -143,7 +143,7 @@ contract ERC2771ForwarderAccount is UUPSUpgradeable, BaseAccount, IAccountExecut
 
   /**
    * @dev Executes a user operation by forwarding the call to the target contract with the signer as the msgSender.
-   *      The calldata is expected to contain this function's selector followed the signer and the ABI-encoded call:
+   *      The calldata is expected to contain this function's selector followed by the signer and the ABI-encoded call:
    *         - signer (address): the signer of the userop, must match the signature
    *         - dest (address): the target contract address (must be the same as _target)
    *         - value (uint256): the amount of ETH to send with the call

--- a/test/test-forwarder-account.js
+++ b/test/test-forwarder-account.js
@@ -17,12 +17,15 @@ const ADDRESSES = {
 };
 
 async function setup(connection) {
-  const { ethers } = connection;
+  const { ethers, networkHelpers: helpers } = connection;
   const [deployer, exec1, exec2, anon, withdraw, admin] = await ethers.getSigners();
 
   const ep = await ethers.getContractAt("IEntryPoint", ADDRESSES.ENTRYPOINT);
   const ERC2771ForwarderAccount = await ethers.getContractFactory("ERC2771ForwarderAccount");
   const account = await ERC2771ForwarderAccount.deploy(ep);
+
+  await helpers.impersonateAccount(ep.target);
+  const epSigner = await ethers.getSigner(ep.target);
 
   const usdc = await initCurrency(
     ethers,
@@ -42,6 +45,7 @@ async function setup(connection) {
     anon,
     connection,
     ep,
+    epSigner,
     ERC2771ForwarderAccount,
     ethers,
     exec1,
@@ -54,7 +58,8 @@ async function setup(connection) {
 
 describe(`ERC2771ForwarderAccount specific tests`, function () {
   it("Forwards the signer as sender to the target contract", async () => {
-    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep } = await loadFixtureOnFork(setup);
+    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
+      await loadFixtureOnFork(setup);
 
     // Account 'exec2' has granted infinite allowance to 'exec1' on 'usdc'
     await usdc.connect(exec2).approve(getAddress(exec1), MaxUint256);
@@ -69,7 +74,10 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
 
     const executeUserOpData = ethers.concat([
       account.interface.getFunction("executeUserOp").selector,
-      ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256", "bytes"], [usdc.target, 0, transferCall]),
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "address", "uint256", "bytes"],
+        [getAddress(exec1), usdc.target, 0, transferCall]
+      ),
     ]);
 
     const nonce = await account.getNonce();
@@ -91,8 +99,7 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const userOpHash = getUserOpHash(userOp, ADDRESSES.ENTRYPOINT, chainId);
 
     // Sanity check: the user op's signature validates
-    await helpers.impersonateAccount(ep.target);
-    const epSigner = await ethers.getSigner(ep.target);
+
     const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationData).to.equal(0);
 
@@ -114,7 +121,8 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
   });
 
   it("Does not allow execute or executeBatch", async () => {
-    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep } = await loadFixtureOnFork(setup);
+    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
+      await loadFixtureOnFork(setup);
 
     await expect(account.connect(anon).execute(getAddress(usdc), 0, "0x")).to.be.revertedWithCustomError(
       account,
@@ -141,7 +149,8 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
   });
 
   it("Can add executors", async () => {
-    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep } = await loadFixtureOnFork(setup);
+    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
+      await loadFixtureOnFork(setup);
 
     const transferCall = usdc.interface.encodeFunctionData("transferFrom", [
       getAddress(exec2),
@@ -151,7 +160,10 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
 
     const executeUserOpData = ethers.concat([
       account.interface.getFunction("executeUserOp").selector,
-      ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256", "bytes"], [usdc.target, 0, transferCall]),
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "address", "uint256", "bytes"],
+        [getAddress(anon), usdc.target, 0, transferCall]
+      ),
     ]);
 
     const { chainId } = await ethers.provider.getNetwork();
@@ -172,15 +184,8 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const userOpHash = getUserOpHash(userOp, ADDRESSES.ENTRYPOINT, chainId);
 
     // The signature is not accepted
-    await helpers.impersonateAccount(ep.target);
-    const epSigner = await ethers.getSigner(ep.target);
     const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationData).to.equal(1);
-
-    // The userop execution is rejected too
-    await expect(account.executeUserOp(packedUserOp, userOpHash))
-      .to.be.revertedWithCustomError(account, "InvalidTarget")
-      .withArgs(getAddress(usdc), getAddress(anon));
 
     // Add 'anon' as executor with 'usdc' as target
     await expect(account.addExecutor(getAddress(anon), usdc))
@@ -195,7 +200,8 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
   });
 
   it("Can remove executors", async () => {
-    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep } = await loadFixtureOnFork(setup);
+    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
+      await loadFixtureOnFork(setup);
 
     const { chainId } = await ethers.provider.getNetwork();
     const userOp = await signUserOp(
@@ -206,8 +212,8 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
           callData: ethers.concat([
             account.interface.getFunction("executeUserOp").selector,
             ethers.AbiCoder.defaultAbiCoder().encode(
-              ["address", "uint256", "bytes"],
-              [usdc.target, 0, usdc.interface.encodeFunctionData("decimals", [])]
+              ["address", "address", "uint256", "bytes"],
+              [getAddress(exec1), usdc.target, 0, usdc.interface.encodeFunctionData("decimals", [])]
             ),
           ]),
         },
@@ -221,8 +227,6 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const userOpHash = getUserOpHash(userOp, ADDRESSES.ENTRYPOINT, chainId);
 
     // The signature is accepted
-    await helpers.impersonateAccount(ep.target);
-    const epSigner = await ethers.getSigner(ep.target);
     const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationData).to.equal(0);
 
@@ -236,5 +240,53 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
       .connect(epSigner)
       .validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationDataAfterRemoval).to.equal(1);
+  });
+
+  it("Validates that the expected signer matches the actual signer", async () => {
+    const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
+      await loadFixtureOnFork(setup);
+
+    // Account 'exec2' has granted infinite allowance to 'exec1' on 'usdc'
+    await usdc.connect(exec2).approve(getAddress(exec1), MaxUint256);
+    expect(await usdc.allowance(exec2, exec1)).to.equal(MaxUint256);
+
+    // UserOp call signed by 'exec1', forwards exec2 as sender
+    const transferCall = usdc.interface.encodeFunctionData("transfer", [getAddress(anon), _A(10)]);
+
+    const executeUserOpData = ethers.concat([
+      account.interface.getFunction("executeUserOp").selector,
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "address", "uint256", "bytes"],
+        // wrongly set the expected signer as exec2 instead of exec1
+        [getAddress(exec2), usdc.target, 0, transferCall]
+      ),
+    ]);
+
+    const nonce = await account.getNonce();
+    const { chainId } = await ethers.provider.getNetwork();
+    const userOp = await signUserOp(
+      fillUserOpDefaults(
+        {
+          sender: getAddress(account),
+          nonce: nonce,
+          callData: executeUserOpData,
+        },
+        TestUserOp
+      ),
+      exec1, // expectedSigner was set to exec2, but the userOp is signed by exec1
+      ADDRESSES.ENTRYPOINT,
+      chainId
+    );
+    const packedUserOp = packedUserOpAsArray(packUserOp(userOp), true);
+    const userOpHash = getUserOpHash(userOp, ADDRESSES.ENTRYPOINT, chainId);
+
+    // The userOp signature does not validate, even though exec2 is an executor
+    const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
+    await expect(validationData).to.equal(1);
+
+    // Calling executeUserOp directly does not validate signature, usdc sees exec2 as sender
+    await expect(account.connect(epSigner).executeUserOp(packedUserOp, userOpHash))
+      .to.emit(usdc, "Transfer")
+      .withArgs(getAddress(exec2), getAddress(anon), _A(10));
   });
 });

--- a/test/test-forwarder-account.js
+++ b/test/test-forwarder-account.js
@@ -246,10 +246,6 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const { account, anon, exec1, exec2, admin, roles, usdc, ethers, helpers, ep, epSigner } =
       await loadFixtureOnFork(setup);
 
-    // Account 'exec2' has granted infinite allowance to 'exec1' on 'usdc'
-    await usdc.connect(exec2).approve(getAddress(exec1), MaxUint256);
-    expect(await usdc.allowance(exec2, exec1)).to.equal(MaxUint256);
-
     // UserOp call signed by 'exec1', forwards exec2 as sender
     const transferCall = usdc.interface.encodeFunctionData("transfer", [getAddress(anon), _A(10)]);
 
@@ -257,7 +253,7 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
       account.interface.getFunction("executeUserOp").selector,
       ethers.AbiCoder.defaultAbiCoder().encode(
         ["address", "address", "uint256", "bytes"],
-        // wrongly set the expected signer as exec2 instead of exec1
+        // wrongly set the expectedSigner as exec2 instead of exec1
         [getAddress(exec2), usdc.target, 0, transferCall]
       ),
     ]);
@@ -284,7 +280,7 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationData).to.equal(1);
 
-    // Calling executeUserOp directly does not validate signature, usdc sees exec2 as sender
+    // Calling executeUserOp directly does not validate the signature, usdc sees exec2 as sender
     await expect(account.connect(epSigner).executeUserOp(packedUserOp, userOpHash))
       .to.emit(usdc, "Transfer")
       .withArgs(getAddress(exec2), getAddress(anon), _A(10));

--- a/test/test-forwarder-account.js
+++ b/test/test-forwarder-account.js
@@ -280,7 +280,12 @@ describe(`ERC2771ForwarderAccount specific tests`, function () {
     const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
     await expect(validationData).to.equal(1);
 
-    // Calling executeUserOp directly does not validate the signature, usdc sees exec2 as sender
+    // Calling executeUserOp directly is not allowed
+    await expect(account.connect(exec1).executeUserOp(packedUserOp, userOpHash)).to.be.revertedWith(
+      "account: not from EntryPoint"
+    );
+
+    // A malicious entrypoint could do that though, in that case usdc sees exec2 as sender
     await expect(account.connect(epSigner).executeUserOp(packedUserOp, userOpHash))
       .to.emit(usdc, "Transfer")
       .withArgs(getAddress(exec2), getAddress(anon), _A(10));


### PR DESCRIPTION
With the existing behaviour, ERC2771ForwarderAccount cannot be properly simulated using eth_estimateUserOp or similar methods, because it ends up checking the dummy signature used for estimations against the authorized executor's targets.

Even if that wasn't an issue, it would then forward the dummy signer to the target contract as _msgSender context (ERC2771), causing that call to fail in most cases.

The fix here introduces a change in the signature validation logic:
1. Signature is only validated in `validateUserOp`
2. Calldata includes the signer address, `validateUserOp` makes sure it matches the actual signature
3. executeUserOp trusts and forwards the address received on the calldata
4. In order to be able to trust this, executeUserOp must only accept calls from the entrypoint, so the guard was added too

This also brings the account more inline with other accounts, and reduces gas cost by not validating the signature twice.

It does restrict executeUserOp to only be called from the entrypoint, but that was already the case for validateUserOp anyway.