### PR TITLE
feat: add Simple7702Account for entrypoint v0.7

### DIFF
--- a/contracts/Simple7702AccountV07.sol
+++ b/contracts/Simple7702AccountV07.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {SIG_VALIDATION_SUCCESS, SIG_VALIDATION_FAILED} from "@account-abstraction/contracts/core/Helpers.sol";
+
+/**
+ * Simple7702AccountV07
+ *
+ * Copy of eth-infinitism's Simple7702Account (v0.8.0, accounts/Simple7702Account.sol in the
+ * account-abstraction package) retargeted to the v0.7 EntryPoint. Copied instead of
+ * inherited+overridden because the original does not mark `entryPoint()` / `_checkSignature()`
+ * as `virtual`.
+ *
+ * Only two things differ from the original:
+ *   1. `entryPoint()` returns the v0.7 EntryPoint (`0x0000000071727De22E5E9d8BAf0edAc6f37da032`).
+ *   2. `_checkSignature()` recovers from the EIP-191 personal-sign digest of the hash
+ *      (`toEthSignedMessageHash(hash)`) before comparing against `address(this)`.
+ */
+contract Simple7702AccountV07 is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC721Holder {
+  function entryPoint() public pure override returns (IEntryPoint) {
+    return IEntryPoint(0x0000000071727De22E5E9d8BAf0edAc6f37da032);
+  }
+
+  /**
+   * Make this account callable through ERC-4337 EntryPoint.
+   * The UserOperation should be signed by this account's private key.
+   */
+  function _validateSignature(
+    PackedUserOperation calldata userOp,
+    bytes32 userOpHash
+  ) internal virtual override returns (uint256 validationData) {
+    return _checkSignature(userOpHash, userOp.signature) ? SIG_VALIDATION_SUCCESS : SIG_VALIDATION_FAILED;
+  }
+
+  function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4 magicValue) {
+    return _checkSignature(hash, signature) ? this.isValidSignature.selector : bytes4(0xffffffff);
+  }
+
+  function _checkSignature(bytes32 hash, bytes memory signature) internal view returns (bool) {
+    return ECDSA.recover(MessageHashUtils.toEthSignedMessageHash(hash), signature) == address(this);
+  }
+
+  function _requireForExecute() internal view virtual override {
+    // solhint-disable-next-line gas-custom-errors
+    require(msg.sender == address(this) || msg.sender == address(entryPoint()), "not from self or EntryPoint");
+  }
+
+  function supportsInterface(bytes4 id) public pure override(ERC1155Holder, IERC165) returns (bool) {
+    return
+      id == type(IERC165).interfaceId ||
+      id == type(IAccount).interfaceId ||
+      id == type(IERC1271).interfaceId ||
+      id == type(IERC1155Receiver).interfaceId ||
+      id == type(IERC721Receiver).interfaceId;
+  }
+
+  // accept incoming calls (with or without value), to mimic an EOA.
+  // solhint-disable-next-line no-empty-blocks
+  fallback() external payable {}
+
+  // solhint-disable-next-line no-empty-blocks
+  receive() external payable {}
+}

--- a/test/test-simple7702-account.js
+++ b/test/test-simple7702-account.js
@@ -1,0 +1,97 @@
+import { _W } from "@ensuro/utils/js/utils";
+import { expect } from "chai";
+import { anyValue } from "@nomicfoundation/hardhat-ethers-chai-matchers/withArgs";
+
+import { getUserOpHash, packUserOp, packedUserOpAsArray, signUserOp, fillUserOpDefaults } from "../js/userOp.js";
+import { loadFixtureOnFork, TestUserOp } from "./utils.js";
+
+// Concise smoke tests for Simple7702AccountV07: delegate an EOA to the implementation via EIP-7702,
+// then drive it through the v0.7 EntryPoint. Not exhaustive.
+
+const ENTRYPOINT = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"; // canonical v0.7 EntryPoint
+
+async function setup(connection) {
+  const { ethers, networkHelpers: helpers } = connection;
+  const [deployer, recipient, anon] = await ethers.getSigners();
+
+  const ep = await ethers.getContractAt("IEntryPoint", ENTRYPOINT);
+  const Simple7702AccountV07 = await ethers.getContractFactory("Simple7702AccountV07");
+  const impl = await Simple7702AccountV07.deploy();
+
+  // The EOA whose key we control; after the 7702 delegation it *is* the account.
+  const eoa = ethers.Wallet.createRandom(ethers.provider);
+  await helpers.setBalance(eoa.address, _W(10));
+
+  const auth = await eoa.authorize({ address: await impl.getAddress() });
+  await deployer.sendTransaction({ type: 4, to: eoa.address, authorizationList: [auth] });
+  const account = Simple7702AccountV07.attach(eoa.address);
+
+  await helpers.impersonateAccount(ENTRYPOINT);
+  const epSigner = await ethers.getSigner(ENTRYPOINT);
+
+  return { account, anon, eoa, ep, epSigner, ethers, impl, recipient };
+}
+
+async function buildUserOp(ethers, account, eoa, signer, callData) {
+  const { chainId } = await ethers.provider.getNetwork();
+  const userOp = await signUserOp(
+    fillUserOpDefaults({ sender: eoa.address, nonce: await account.getNonce(), callData }, TestUserOp),
+    signer,
+    ENTRYPOINT,
+    chainId
+  );
+  return {
+    packedUserOp: packedUserOpAsArray(packUserOp(userOp), true),
+    userOpHash: getUserOpHash(userOp, ENTRYPOINT, chainId),
+  };
+}
+
+describe("Simple7702AccountV07 smoke tests", function () {
+  it("entryPoint() returns the v0.7 EntryPoint", async () => {
+    const { impl } = await loadFixtureOnFork(setup);
+    expect(await impl.entryPoint()).to.equal(ENTRYPOINT);
+  });
+
+  it("executes a userOp end-to-end through the v0.7 EntryPoint", async () => {
+    const { account, anon, eoa, ep, epSigner, ethers, recipient } = await loadFixtureOnFork(setup);
+
+    const callData = account.interface.encodeFunctionData("execute", [recipient.address, _W(1), "0x"]);
+    const { packedUserOp, userOpHash } = await buildUserOp(ethers, account, eoa, eoa, callData);
+
+    // Sanity: the signature (EIP-191 personal-sign of userOpHash, recovered to address(this) == eoa) validates.
+    const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
+    expect(validationData).to.equal(0n);
+
+    const tx = await ep.handleOps([packedUserOp], anon.address, { gasLimit: 1000000n });
+
+    // These assertions cannot be chained (see test-forwarder-account.js).
+    await expect(tx)
+      .to.emit(ep, "UserOperationEvent")
+      .withArgs(userOpHash, eoa.address, anyValue, anyValue, true, anyValue, anyValue);
+    await expect(tx).to.changeEtherBalance(ethers, recipient, _W(1));
+  });
+
+  it("only allows execute() from the account itself or the EntryPoint", async () => {
+    const { account, anon, eoa, ethers, recipient } = await loadFixtureOnFork(setup);
+
+    await expect(account.connect(anon).execute(recipient.address, 0, "0x")).to.be.revertedWith(
+      "not from self or EntryPoint"
+    );
+
+    await expect(account.connect(eoa).execute(recipient.address, 123n, "0x")).to.changeEtherBalance(
+      ethers,
+      recipient,
+      123n
+    );
+  });
+
+  it("rejects a userOp signed by a different key (no revert)", async () => {
+    const { account, anon, eoa, epSigner, ethers, recipient } = await loadFixtureOnFork(setup);
+
+    const callData = account.interface.encodeFunctionData("execute", [recipient.address, _W(1), "0x"]);
+    const { packedUserOp, userOpHash } = await buildUserOp(ethers, account, eoa, anon, callData);
+
+    const validationData = await account.connect(epSigner).validateUserOp.staticCall(packedUserOp, userOpHash, 0n);
+    expect(validationData).to.equal(1n);
+  });
+});


### PR DESCRIPTION
The new contract is just a copy of eth-infinitism Simple7702Account, with two differences to support entrypoint v0.7.

The tests are deliberately simple and "smoke-test" like, because I'm not sure at this point whether we'll move forward with this approach or just upgrade our stack to erc4337 v0.8 or v0.9.


```diff
--- eth-infinitism-account-abstraction/contracts/accounts/Simple7702Account.sol      2026-01-29 13:25:33.397138116 -0300
+++ contracts/Simple7702AccountV07.sol  2026-06-17 23:38:33.378203411 -0300
@@ -1,23 +1,36 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
-import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "../core/Helpers.sol";
-import "../core/BaseAccount.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {SIG_VALIDATION_SUCCESS, SIG_VALIDATION_FAILED} from "@account-abstraction/contracts/core/Helpers.sol";
 
 /**
- * Simple7702Account.sol
- * A minimal account to be used with EIP-7702 (for batching) and ERC-4337 (for gas sponsoring)
+ * Simple7702AccountV07
+ *
+ * Copy of eth-infinitism's Simple7702Account (v0.8.0, accounts/Simple7702Account.sol in the
+ * account-abstraction package) retargeted to the v0.7 EntryPoint. Copied instead of
+ * inherited+overridden because the original does not mark `entryPoint()` / `_checkSignature()`
+ * as `virtual`.
+ *
+ * Only two things differ from the original:
+ *   1. `entryPoint()` returns the v0.7 EntryPoint (`0x0000000071727De22E5E9d8BAf0edAc6f37da032`).
+ *   2. `_checkSignature()` recovers from the EIP-191 personal-sign digest of the hash
+ *      (`toEthSignedMessageHash(hash)`) before comparing against `address(this)`.
  */
-contract Simple7702Account is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC721Holder {
-
-    // temporary address of entryPoint v0.8
+contract Simple7702AccountV07 is BaseAccount, IERC165, IERC1271, ERC1155Holder, ERC721Holder {
     function entryPoint() public pure override returns (IEntryPoint) {
-        return IEntryPoint(0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108);
+    return IEntryPoint(0x0000000071727De22E5E9d8BAf0edAc6f37da032);
     }
 
     /**
@@ -37,18 +49,15 @@
     }
 
     function _checkSignature(bytes32 hash, bytes memory signature) internal view returns (bool) {
-        return ECDSA.recover(hash, signature) == address(this);
+    return ECDSA.recover(MessageHashUtils.toEthSignedMessageHash(hash), signature) == address(this);
     }
 
     function _requireForExecute() internal view virtual override {
-        require(
-            msg.sender == address(this) ||
-            msg.sender == address(entryPoint()),
-            "not from self or EntryPoint"
-        );
+    // solhint-disable-next-line gas-custom-errors
+    require(msg.sender == address(this) || msg.sender == address(entryPoint()), "not from self or EntryPoint");
     }
 
-    function supportsInterface(bytes4 id) public override(ERC1155Holder, IERC165) pure returns (bool) {
+  function supportsInterface(bytes4 id) public pure override(ERC1155Holder, IERC165) returns (bool) {
         return
             id == type(IERC165).interfaceId ||
             id == type(IAccount).interfaceId ||
@@ -58,9 +67,9 @@
     }
 
     // accept incoming calls (with or without value), to mimic an EOA.
-    fallback() external payable {
-    }
+  // solhint-disable-next-line no-empty-blocks
+  fallback() external payable {}
 
-    receive() external payable {
-    }
+  // solhint-disable-next-line no-empty-blocks
+  receive() external payable {}
 }
```